### PR TITLE
refactor node workflows

### DIFF
--- a/templates/monorepo-service/.github/workflows/pull-request.yaml
+++ b/templates/monorepo-service/.github/workflows/pull-request.yaml
@@ -7,34 +7,12 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@indivorg'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2.1.6
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Configure yarn
-        run: yarn config set 'npmScopes["indivorg"].npmAuthToken' ${{ secrets.INDIVBOT_GITHUB_TOKEN }}
-
+          cache: 'yarn'
       - run: yarn install
-
       - run: yarn build
-
       - run: yarn test --passWithNoTests
+

--- a/templates/monorepo-service/.github/workflows/push.yml
+++ b/templates/monorepo-service/.github/workflows/push.yml
@@ -19,28 +19,14 @@ jobs:
           step: start
           token: ${{ secrets.INDIVBOT_GITHUB_TOKEN }}
           env: production
+
       - name: Checkout 🛎️
         uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache NPM packages 👾
-        uses: actions/cache@v2.1.6
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Configure yarn
-        run: yarn config set 'npmScopes["indivorg"].npmAuthToken' ${{ secrets.INDIVBOT_GITHUB_TOKEN }}
+          node-version: '14.x'
+          cache: 'yarn'
 
       - name: Install packages 📦
         run: yarn

--- a/templates/service/.github/workflows/pull-request.yaml
+++ b/templates/service/.github/workflows/pull-request.yaml
@@ -8,32 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 1
-
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-          registry-url: https://npm.pkg.github.com/
-          scope: '@indivorg'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2.1.6
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
+          cache: 'yarn'
       - run: yarn install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.INDIVBOT_GITHUB_TOKEN }}
-
       - run: yarn build
-
       - run: yarn test --passWithNoTests


### PR DESCRIPTION
We need to clean up references to our Github NPM Registry packages – and since [setup-node now supports dependency caching](https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/), I activated that instead. Result: Much cleaner workflows!
