### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v5
         id: search
         with:
           result-encoding: string

--- a/templates/monorepo-service/.github/workflows/canary-release.yaml
+++ b/templates/monorepo-service/.github/workflows/canary-release.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - run: gcloud auth configure-docker
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
 
       - name: Docker meta
         id: meta

--- a/templates/monorepo-service/.github/workflows/pull-request.yaml
+++ b/templates/monorepo-service/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'

--- a/templates/monorepo-service/.github/workflows/push.yml
+++ b/templates/monorepo-service/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
           env: production
 
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.4.0
 
       - uses: actions/setup-node@v2
         with:

--- a/templates/monorepo-service/.github/workflows/push.yml
+++ b/templates/monorepo-service/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Start Deployment
-        uses: bobheadxi/deployments@v0.6.0
+        uses: bobheadxi/deployments@v0.6.1
         id: deployment
         with:
           step: start
@@ -50,7 +50,7 @@ jobs:
           FIREBASE_CLI_PREVIEWS: hostingchannels
 
       - name: Update Deployment Status
-        uses: bobheadxi/deployments@v0.6.0
+        uses: bobheadxi/deployments@v0.6.1
         if: always()
         with:
           step: finish

--- a/templates/service/.github/workflows/canary-release.yaml
+++ b/templates/service/.github/workflows/canary-release.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - run: gcloud auth configure-docker
 
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
 
       - name: Docker meta
         id: meta

--- a/templates/service/.github/workflows/pull-request.yaml
+++ b/templates/service/.github/workflows/pull-request.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'

--- a/templates/service/Dockerfile
+++ b/templates/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.3-alpine as build
+FROM node:17.0.1-alpine as build
 
 WORKDIR /usr/src/app
 
@@ -12,7 +12,7 @@ COPY . .
 
 RUN yarn build
 
-FROM node:14.17.3-alpine
+FROM node:17.0.1-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* chore(deps): bump actions/checkout from 2.3.4 to 2.4.0 in /templates/monorepo-service (#28) @dependabot
* chore(deps): bump actions/checkout from 2.3.4 to 2.4.0 in /templates/service (#27) @dependabot
* chore(deps): bump bobheadxi/deployments from 0.6.0 to 0.6.1 in /templates/monorepo-service (#26) @dependabot
* chore(deps): bump node from 14.17.3-alpine to 17.0.1-alpine in /templates/service (#25) @dependabot
* chore(deps): bump actions/github-script from 4 to 5 (#20) @dependabot
